### PR TITLE
Add/enhanced link attribution universal

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,6 +117,11 @@ GA.prototype.initialize = function() {
     window.ga('require', 'displayfeatures');
   }
 
+  // https://support.google.com/analytics/answer/2558867?hl=en
+  if (opts.enhancedLinkAttribution) {
+    window.ga('require', 'linkid', 'linkid.js');
+  }
+
   // send global id
   if (opts.sendUserId && user.id()) {
     window.ga('set', 'userId', user.id());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,6 +77,13 @@ describe('Google Analytics', function() {
           analytics.deepEqual(window.ga.q[1], ['require', 'displayfeatures']);
         });
 
+        it('should require "linkid.js" if enhanced link attribution is `true`', function() {
+          ga.options.enhancedLinkAttribution = true;
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[1], ['require', 'linkid', 'linkid.js']);
+        });
+
         it('should create window.GoogleAnalyticsObject', function() {
           analytics.assert(!window.GoogleAnalyticsObject);
           analytics.initialize();


### PR DESCRIPTION
checks if universal settings has enhanced link attribution enabled, if it does, requires `linkid.js` to the `window.ga`

Ref: https://support.google.com/analytics/answer/2558867?hl=en
