### PR TITLE
support enhanced eccommerce product coupon level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -838,8 +838,7 @@ GA.prototype.clickedPromotionEnhanced = function(track) {
 
 function enhancedEcommerceTrackProduct(track) {
   var props = track.properties();
-
-  window.ga('ec:addProduct', {
+  var product = {
     id: track.id() || track.sku(),
     name: track.name(),
     category: track.category(),
@@ -848,7 +847,13 @@ function enhancedEcommerceTrackProduct(track) {
     brand: props.brand,
     variant: props.variant,
     currency: track.currency()
-  });
+  };
+
+  // append coupon if it set
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-transactions
+  var coupon = track.proxy('properties.coupon');
+  if (coupon) product.coupon = coupon;
+  window.ga('ec:addProduct', product);
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1119,6 +1119,66 @@ describe('Google Analytics', function() {
           analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'completed order', { nonInteraction: 1 }]);
         });
 
+        it('should add coupon to product level in completed order', function() {
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            total: 99.9,
+            shipping: 13.99,
+            tax: 20.99,
+            currency: 'CAD',
+            coupon: 'coupon',
+            affiliation: 'affiliation',
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              category: 'cat 1',
+              sku: 'p-298',
+              coupon: 'promo'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              category: 'cat 2',
+              sku: 'p-299',
+              currency: 'EUR'
+            }]
+          });
+
+          analytics.assert(window.ga.args.length === 6);
+          analytics.deepEqual(window.ga.args[1], ['set', '&cu', 'CAD']);
+          analytics.deepEqual(window.ga.args[2], ['ec:addProduct', {
+            id: 'p-298',
+            name: 'my product',
+            category: 'cat 1',
+            quantity: 1,
+            price: 24.75,
+            brand: undefined,
+            variant: undefined,
+            currency: 'CAD',
+            coupon: 'promo'
+          }]);
+          analytics.deepEqual(window.ga.args[3], ['ec:addProduct', {
+            id: 'p-299',
+            name: 'other product',
+            category: 'cat 2',
+            quantity: 3,
+            price: 24.75,
+            brand: undefined,
+            variant: undefined,
+            currency: 'EUR'
+          }]);
+          analytics.deepEqual(window.ga.args[4], ['ec:setAction', 'purchase', {
+            id: '780bc55',
+            affiliation: 'affiliation',
+            revenue: 99.9,
+            tax: 20.99,
+            shipping: 13.99,
+            coupon: 'coupon'
+          }]);
+          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'completed order', { nonInteraction: 1 }]);
+        });
+
         it('completed order should fallback to revenue', function() {
           analytics.track('completed order', {
             orderId: '5d4c7cb5',


### PR DESCRIPTION
GA enhanced eccommerce supports coupons to be added to the product level in a completed order event:

https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-transactions

added a lookup to check if the coupon is set for a product level since we are not spec'ing this.

@sperand-io 
