### PR TITLE
Do not update the document location for Single Page Applications

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('siteSpeedSampleRate', 1)
   .option('trackCategorizedPages', true)
   .option('trackNamedPages', true)
+  .option('singlePageApplication', false)
   .option('trackingId', '')
   .tag('library', '<script src="//www.google-analytics.com/analytics.js">')
   .tag('double click', '<script src="//stats.g.doubleclick.net/dc.js">')
@@ -182,6 +183,16 @@ GA.prototype.page = function(page) {
   if (campaign.medium) pageview.campaignMedium = campaign.medium;
   if (campaign.content) pageview.campaignContent = campaign.content;
   if (campaign.term) pageview.campaignKeyword = campaign.term;
+
+  /**
+   * Single Page Application Tracking
+   * Do not update the document location
+   *
+   * https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#do-not-update-the-document-location
+   */
+  if (this.options.singlePageApplication) {
+    delete pageview.location;
+  }
 
   // custom dimensions and metrics
   var custom = metrics(props, opts);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,6 +44,7 @@ describe('Google Analytics', function() {
       .option('siteSpeedSampleRate', 1)
       .option('trackCategorizedPages', true)
       .option('trackNamedPages', true)
+      .option('singlePageApplication', false)
       .option('trackingId', ''));
   });
 
@@ -359,6 +360,15 @@ describe('Google Analytics', function() {
           analytics.assert(window.ga.args[1][0] === 'send');
           analytics.assert(window.ga.args[2][0] === 'set');
           analytics.assert(window.ga.args[3][0] === 'send');
+        });
+
+        it('should not update the document location for Single Page Applications', function() {
+          ga.options.singlePageApplication = true;
+          analytics.page();
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: window.location.pathname,
+            title: document.title
+          });
         });
       });
 


### PR DESCRIPTION
According to the [Google documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#do-not-update-the-document-location), the document `location` should not be updated for Single Page Applications:

> In the same way that the tracker uses document.referrer for the referrer field, it uses document.location for the location field, which will often contain campaign data or other meta data in the form of query parameters appended to the end of the URL.
> 
> Updating any of the campaign fields or other meta data that Google Analytics is checking for may cause the current session to end and a new session to begin. To avoid this problem, do not update the location field when tracking virtual pageviews in a single page application. Use the page field instead.

Following the discussion in #12, this PR adds a flag to implement the correct behaviour.
