### PR TITLE
omit location from subsequent page() calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,7 @@ GA.on('construct', function(integration) {
  */
 
 GA.prototype.initialize = function() {
+  this.pageCalled = false;
   var opts = this.options;
 
   // setup the tracker globals
@@ -190,6 +191,8 @@ GA.prototype.page = function(page) {
   // set
   window.ga('set', { page: pagePath, title: pageTitle });
 
+  if (this.pageCalled) delete pageview.location;
+
   // send
   window.ga('send', 'pageview', pageview);
 
@@ -204,6 +207,8 @@ GA.prototype.page = function(page) {
     track = page.track(name);
     this.track(track, { nonInteraction: 1 });
   }
+
+  this.pageCalled = true;
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,7 +212,6 @@ describe('Google Analytics', function() {
       beforeEach(function(done) {
         analytics.once('ready', done);
         analytics.initialize();
-        analytics.page();
       });
 
       describe('#page', function() {
@@ -226,6 +225,20 @@ describe('Google Analytics', function() {
             page: window.location.pathname,
             title: document.title,
             location: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search
+          });
+        });
+
+        it('should omit location on subsequent page views', function() {
+          analytics.page();
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: window.location.pathname,
+            title: document.title,
+            location: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search
+          });
+          analytics.page();
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: window.location.pathname,
+            title: document.title
           });
         });
 


### PR DESCRIPTION
This POC takes the "flag" approach to omission of `location` on subsequent invocations of page in lieu of adding any new options. Since this is apparently the correct behavior I don't think we should make it optional :)

Need to cherry pick the tests from #13 

Thoughts to this approach as an alternative @f2prateek @hankim813?
