### PR TITLE
Adds support for setting content groupings via tracking code.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .global('GoogleAnalyticsObject')
   .option('anonymizeIp', false)
   .option('classic', false)
+  .option('contentGroupings', {})
   .option('dimensions', {})
   .option('domain', 'auto')
   .option('doubleClick', false)
@@ -184,7 +185,7 @@ GA.prototype.page = function(page) {
   if (campaign.content) pageview.campaignContent = campaign.content;
   if (campaign.term) pageview.campaignKeyword = campaign.term;
 
-  // custom dimensions and metrics
+  // custom dimensions, metrics and content groupings
   var custom = metrics(props, opts);
   if (len(custom)) window.ga('set', custom);
 
@@ -499,7 +500,7 @@ function formatValue(value) {
 }
 
 /**
- * Map google's custom dimensions & metrics with `obj`.
+ * Map google's custom dimensions, metrics & content groupings with `obj`.
  *
  * Example:
  *
@@ -518,12 +519,13 @@ function formatValue(value) {
 function metrics(obj, data) {
   var dimensions = data.dimensions;
   var metrics = data.metrics;
-  var names = keys(metrics).concat(keys(dimensions));
+  var contentGroupings = data.contentGroupings;
+  var names = keys(metrics).concat(keys(dimensions)).concat(keys(contentGroupings));
   var ret = {};
 
   for (var i = 0; i < names.length; ++i) {
     var name = names[i];
-    var key = metrics[name] || dimensions[name];
+    var key = metrics[name] || dimensions[name] || contentGroupings[name];
     var value = dot(obj, name) || obj[name];
     if (value == null) continue;
     if (is.boolean(value)) value = value.toString();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,7 @@ describe('Google Analytics', function() {
       .global('GoogleAnalyticsObject')
       .option('anonymizeIp', false)
       .option('classic', false)
+      .option('contentGroupings', {})
       .option('dimensions', {})
       .option('domain', 'auto')
       .option('doubleClick', false)
@@ -158,9 +159,10 @@ describe('Google Analytics', function() {
           }]);
         });
 
-        it('should not set metrics and dimensions if there are no traits', function() {
+        it('should not set metrics, dimensions and content groupings if there are no traits', function() {
           ga.options.metrics = { metric1: 'something' };
           ga.options.dimensions = { dimension3: 'industry' };
+          ga.options.contentGroupings = { contentGrouping1: 'foo' };
           analytics.initialize();
           analytics.page();
           analytics.deepEqual(window.ga.q[2], undefined);
@@ -292,15 +294,17 @@ describe('Google Analytics', function() {
           });
         });
 
-        it('should map custom dimensions & metrics using track.properties()', function() {
+        it('should map custom dimensions, metrics & content groupings using track.properties()', function() {
           ga.options.metrics = { score: 'metric1' };
           ga.options.dimensions = { author: 'dimension1', postType: 'dimension2' };
-          analytics.page({ score: 21, author: 'Author', postType: 'blog' });
+          ga.options.contentGroupings = { section: 'contentGrouping1' };
+          analytics.page({ score: 21, author: 'Author', postType: 'blog', section: 'News' });
 
           analytics.called(window.ga, 'set', {
             metric1: 21,
             dimension1: 'Author',
-            dimension2: 'blog'
+            dimension2: 'blog',
+            contentGrouping1: 'News'
           });
         });
 


### PR DESCRIPTION
Google Analytics supports 1-5 content groupings which are set in the same manner as metrics and dimensions. E.g. `ga('set', 'contentGroup<Index Number>', '<Group Name>');` This commit adds support for setting content groupings in the same way that metrics and dimensions are set.

For more info: https://support.google.com/analytics/answer/2853546?hl=en&ref_topic=1727167

Example usage:

```
analytics.initialize({
    'Google Analytics': {
        trackingId: 'UA-XXXXXX-X',
        'metrics': {
            'Test Metric': 'metric1',
            'Test Event Metric': 'metric2'
        },
        'dimensions': {
            'Test Dimension': 'dimension1',
            'Test Event Dimension': 'dimension2'
        },
        'contentGroupings': {
            'Site Section': 'contentGroup1'
        }
    }
});

analytics.page(null, {
    'Test Metric': 1,
    'Test Dimension': 'Test',
    'Site Section': 'Test'
});

analytics.track('Test Event', {
    'Test Event Metric': 1,
    'Test Event Dimension': 'Test'
});
```

This fixes issue #4 

CC: @bbeaird @DirtyAnalytics 
