### PR TITLE
Adds support for setting content groupings via tracking code.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,13 @@ GA.prototype.page = function(page) {
   var custom = metrics(props, opts);
   if (len(custom)) window.ga('set', custom);
 
+  // content groupings
+  if (props.contentGroup1) window.ga('set', 'contentGroup1', props.contentGroup1);
+  if (props.contentGroup2) window.ga('set', 'contentGroup2', props.contentGroup2);
+  if (props.contentGroup3) window.ga('set', 'contentGroup3', props.contentGroup3);
+  if (props.contentGroup4) window.ga('set', 'contentGroup4', props.contentGroup4);
+  if (props.contentGroup5) window.ga('set', 'contentGroup5', props.contentGroup5);
+
   // set
   window.ga('set', { page: pagePath, title: pageTitle });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -259,6 +259,21 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should send a page view with content groupings', function() {
+          analytics.page('category', 'name', {
+            contentGroup1: 'Test 1',
+            contentGroup2: 'Test 2',
+            contentGroup3: 'Test 3',
+            contentGroup4: 'Test 4',
+            contentGroup5: 'Test 5'
+          });
+          analytics.called(window.ga, 'set', 'contentGroup1', 'Test 1');
+          analytics.called(window.ga, 'set', 'contentGroup2', 'Test 2');
+          analytics.called(window.ga, 'set', 'contentGroup3', 'Test 3');
+          analytics.called(window.ga, 'set', 'contentGroup4', 'Test 4');
+          analytics.called(window.ga, 'set', 'contentGroup5', 'Test 5');
+        });
+
         it('should send the query if its included', function() {
           ga.options.includeSearch = true;
           analytics.page('category', 'name', { url: 'url', path: '/path', search: '?q=1' });


### PR DESCRIPTION
Google Analytics supports 1-5 content groupings which are set in the same manner as metrics and dimensions. E.g. `ga('set', 'contentGroup<Index Number>', '<Group Name>');`

This is an alternative method of setting content groupings to pull #16 which doesn't require any changes to the Segment.com interface to work, and is also more inline with the original suggestion in #4 by @DirtyAnalytics 

Example usage:

```
analytics.initialize({
    'Google Analytics': {
        trackingId: 'UA-72491579-1'
    }
});

analytics.page(null, {
    'contentGroup1': 'Test 1',
    'contentGroup2': 'Test 2',
    'contentGroup3': 'Test 3',
    'contentGroup4': 'Test 4',
    'contentGroup5': 'Test 5',
});
```
