### PR TITLE
refactor metrics/dimension/cg decoration function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@ var dot = require('obj-case');
 var each = require('each');
 var integration = require('analytics.js-integration');
 var is = require('is');
-var keys = require('object').keys;
 var len = require('object').length;
 var push = require('global-queue')('_gaq');
 var select = require('select');
@@ -520,17 +519,16 @@ function metrics(obj, data) {
   var dimensions = data.dimensions;
   var metrics = data.metrics;
   var contentGroupings = data.contentGroupings;
-  var names = keys(metrics).concat(keys(dimensions)).concat(keys(contentGroupings));
+
   var ret = {};
 
-  for (var i = 0; i < names.length; ++i) {
-    var name = names[i];
-    var key = metrics[name] || dimensions[name] || contentGroupings[name];
-    var value = dot(obj, name) || obj[name];
-    if (value == null) continue;
-    if (is.boolean(value)) value = value.toString();
-    ret[key] = value;
-  }
+  each([metrics, dimensions, contentGroupings], function(group) {
+    each(group, function(prop, key){
+      var value = dot(obj, prop) || obj[prop];
+      if (is.boolean(value)) value = value.toString();
+      if (value) ret[key] = value;
+    });
+  });
 
   return ret;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -308,6 +308,21 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should map custom dimensions, metrics & content groupings even if mapped to the same key', function() {
+          ga.options.metrics = { score: 'metric1' };
+          ga.options.dimensions = { author: 'dimension1', postType: 'dimension2' };
+          ga.options.contentGroupings = { section: 'contentGrouping1', score: 'contentGrouping5' };
+          analytics.page({ score: 21, author: 'Author', postType: 'blog', section: 'News' });
+
+          analytics.called(window.ga, 'set', {
+            metric1: 21,
+            dimension1: 'Author',
+            dimension2: 'blog',
+            contentGrouping1: 'News',
+            contentGrouping5: 21
+          });
+        });
+
         it('should track a named page', function() {
           analytics.page('Name');
           analytics.called(window.ga, 'send', 'event', {


### PR DESCRIPTION
... to accomodate mapping the same property to multiple fields (ie. `property_x` to both a custom dimension and a content grouping)

New test case (was failing) demonstrates the issue.
