### PR TITLE
add optional list prop to EE events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -764,8 +764,13 @@ GA.prototype.removedProductEnhanced = function(track) {
  */
 
 GA.prototype.viewedProductEnhanced = function(track) {
+  var props = track.properties();
+  var data = {};
+
   this.loadEnhancedEcommerce(track);
-  enhancedEcommerceProductAction(track, 'detail');
+  // list property is optional
+  if (props.list) data.list = props.list;
+  enhancedEcommerceProductAction(track, 'detail', data);
   this.pushEnhancedEcommerce(track);
 };
 
@@ -780,11 +785,12 @@ GA.prototype.viewedProductEnhanced = function(track) {
 
 GA.prototype.clickedProductEnhanced = function(track) {
   var props = track.properties();
+  var data = {};
 
   this.loadEnhancedEcommerce(track);
-  enhancedEcommerceProductAction(track, 'click', {
-    list: props.list
-  });
+  // list property is optional
+  if (props.list) data.list = props.list;
+  enhancedEcommerceProductAction(track, 'click', data);
   this.pushEnhancedEcommerce(track);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -829,7 +829,8 @@ describe('Google Analytics', function() {
             price: 24.75,
             name: 'my product',
             category: 'cat 1',
-            sku: 'p-298'
+            sku: 'p-298',
+            list: 'Apparel Gallery'
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -844,7 +845,9 @@ describe('Google Analytics', function() {
             variant: undefined,
             currency: 'CAD'
           }]);
-          analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'detail', {}]);
+          analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'detail', {
+            list: 'Apparel Gallery'
+          }]);
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'viewed product', { nonInteraction: 1 }]);
         });
 


### PR DESCRIPTION
@f2prateek This is for https://segment.phacility.com/T845

We already support list prop for EE event `Clicked Product` event but not for `Viewed Product` despite the GA documentation here: https://developers.google.com/tag-manager/enhanced-ecommerce#details

I've added support and modified the logic so that we don't send it if `list` property does not exist. 

TODO: Update Docs
