### PR TITLE
add support for custom dimension and metrics for ee events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -519,7 +519,6 @@ function metrics(obj, data) {
   var dimensions = data.dimensions;
   var metrics = data.metrics;
   var contentGroupings = data.contentGroupings;
-
   var ret = {};
 
   each([metrics, dimensions, contentGroupings], function(group) {
@@ -611,12 +610,13 @@ GA.prototype.viewedCheckoutStepEnhanced = function(track) {
   var products = track.products();
   var props = track.properties();
   var options = extractCheckoutOptions(props);
+  var self = this;
 
   this.loadEnhancedEcommerce(track);
 
   each(products, function(product) {
     var productTrack = createProductTrack(track, product);
-    enhancedEcommerceTrackProduct(productTrack);
+    enhancedEcommerceTrackProduct(productTrack, self.options);
   });
 
   window.ga('ec:setAction', 'checkout', {
@@ -667,15 +667,15 @@ GA.prototype.completedOrderEnhanced = function(track) {
   var orderId = track.orderId();
   var products = track.products();
   var props = track.properties();
+  var self = this;
 
   // orderId is required.
   if (!orderId) return;
 
   this.loadEnhancedEcommerce(track);
-
   each(products, function(product) {
     var productTrack = createProductTrack(track, product);
-    enhancedEcommerceTrackProduct(productTrack);
+    enhancedEcommerceTrackProduct(productTrack, self.options);
   });
 
   window.ga('ec:setAction', 'purchase', {
@@ -735,7 +735,7 @@ GA.prototype.refundedOrderEnhanced = function(track) {
 
 GA.prototype.addedProductEnhanced = function(track) {
   this.loadEnhancedEcommerce(track);
-  enhancedEcommerceProductAction(track, 'add');
+  enhancedEcommerceProductAction(track, 'add', {}, this.options);
   this.pushEnhancedEcommerce(track);
 };
 
@@ -750,7 +750,7 @@ GA.prototype.addedProductEnhanced = function(track) {
 
 GA.prototype.removedProductEnhanced = function(track) {
   this.loadEnhancedEcommerce(track);
-  enhancedEcommerceProductAction(track, 'remove');
+  enhancedEcommerceProductAction(track, 'remove', {}, this.options);
   this.pushEnhancedEcommerce(track);
 };
 
@@ -770,7 +770,7 @@ GA.prototype.viewedProductEnhanced = function(track) {
   this.loadEnhancedEcommerce(track);
   // list property is optional
   if (props.list) data.list = props.list;
-  enhancedEcommerceProductAction(track, 'detail', data);
+  enhancedEcommerceProductAction(track, 'detail', data, this.options);
   this.pushEnhancedEcommerce(track);
 };
 
@@ -790,7 +790,7 @@ GA.prototype.clickedProductEnhanced = function(track) {
   this.loadEnhancedEcommerce(track);
   // list property is optional
   if (props.list) data.list = props.list;
-  enhancedEcommerceProductAction(track, 'click', data);
+  enhancedEcommerceProductAction(track, 'click', data, this.options);
   this.pushEnhancedEcommerce(track);
 };
 
@@ -807,6 +807,8 @@ GA.prototype.viewedPromotionEnhanced = function(track) {
   var props = track.properties();
 
   this.loadEnhancedEcommerce(track);
+
+  // Should these EE events also allow for CD && CM mapping? GA doesn't mention
   window.ga('ec:addPromo', {
     id: track.id(),
     name: track.name(),
@@ -829,6 +831,8 @@ GA.prototype.clickedPromotionEnhanced = function(track) {
   var props = track.properties();
 
   this.loadEnhancedEcommerce(track);
+
+  // Should these EE events also allow for CD && CM mapping? GA doesn't mention
   window.ga('ec:addPromo', {
     id: track.id(),
     name: track.name(),
@@ -848,7 +852,7 @@ GA.prototype.clickedPromotionEnhanced = function(track) {
  * @param {Track} track
  */
 
-function enhancedEcommerceTrackProduct(track) {
+function enhancedEcommerceTrackProduct(track, options) {
   var props = track.properties();
   var product = {
     id: track.id() || track.sku(),
@@ -860,6 +864,16 @@ function enhancedEcommerceTrackProduct(track) {
     variant: props.variant,
     currency: track.currency()
   };
+
+  // custom dimensions & metrics
+  // http://trevorfox.com/2014/11/enhanced-ecommerce-product-dimensions-metrics
+  var custom = metrics(props, options);
+  if (len(custom)) {
+    for (var dimensionsOrMetrics in custom) {
+      if (!custom.hasOwnProperty(dimensionsOrMetrics)) continue;
+      product[dimensionsOrMetrics] = custom[dimensionsOrMetrics];
+    }
+  }
 
   // append coupon if it set
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-transactions
@@ -877,8 +891,8 @@ function enhancedEcommerceTrackProduct(track) {
  * @param {Object} data
  */
 
-function enhancedEcommerceProductAction(track, action, data) {
-  enhancedEcommerceTrackProduct(track);
+function enhancedEcommerceProductAction(track, action, data, settings) {
+  enhancedEcommerceTrackProduct(track, settings);
   window.ga('ec:setAction', action, data || {});
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1271,6 +1271,89 @@ describe('Google Analytics', function() {
           }]);
           analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'refunded order', { nonInteraction: 1 }]);
         });
+
+        it('should map custom dimensions and metrics in completed order', function() {
+          ga.options.metrics = { score: 'metric1' };
+          ga.options.dimensions = { author: 'dimension1', postType: 'dimension2' };
+
+          analytics.track('Completed Order', {
+              orderId: 'af5ccd73',
+              total: 99.99,
+              shipping: 13.99,
+              tax: 20.99,
+              products: [{
+                quantity: 1,
+                price: 24.75,
+                name: 'my product',
+                sku: 'p-298',
+                score: 'hello',
+                author: 'han',
+                category: 'games'
+              }, {
+                quantity: 3,
+                price: 24.75,
+                name: 'other product',
+                sku: 'p-299',
+                postType: 'teemo'
+              }]
+          });
+
+          analytics.assert(window.ga.args.length === 6);
+          analytics.deepEqual(window.ga.args[2], ['ec:addProduct', {
+            id: 'p-298',
+            name: 'my product',
+            category: 'games',
+            quantity: 1,
+            price: 24.75,
+            currency: 'USD',
+            dimension1: 'han',
+            metric1: 'hello',
+            brand: undefined,
+            variant: undefined
+          }]);
+          analytics.deepEqual(window.ga.args[3], ['ec:addProduct', {
+            id: 'p-299',
+            name: 'other product',
+            quantity: 3,
+            price: 24.75,
+            brand: undefined,
+            variant: undefined,
+            category: undefined,
+            currency: 'USD',
+            dimension2: 'teemo'
+          }]);
+        });
+
+        it('should map custom dimensions and metrics in completed order', function() {
+          ga.options.metrics = { score: 'metric1' };
+          ga.options.dimensions = { author: 'dimension1', postType: 'dimension2' };
+
+          analytics.track('added product', {
+            currency: 'CAD',
+            quantity: 1,
+            price: 24.75,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            score: 9000,
+            author: 'han'
+          });
+
+          analytics.assert(window.ga.args.length === 5);
+          analytics.deepEqual(window.ga.args[1], ['set', '&cu', 'CAD']);
+          analytics.deepEqual(window.ga.args[2], ['ec:addProduct', {
+            id: 'p-298',
+            name: 'my product',
+            category: 'cat 1',
+            quantity: 1,
+            price: 24.75,
+            brand: undefined,
+            variant: undefined,
+            currency: 'CAD',
+            metric1: 9000,
+            dimension1: 'han'
+          }]);
+        });
       });
     });
   });


### PR DESCRIPTION
Continue'd from this [PR](https://github.com/segment-integrations/analytics.js-integration-google-analytics/pull/15).

@tejasmanohar originally was putting the CM and CD onto the `set` which is not what we want to do as @sperand-io mentioned. 

After reading some blogs like this [one](http://trevorfox.com/2014/11/enhanced-ecommerce-product-dimensions-metrics) which shows examples of how to add custom metrics and dimensions at the product scope level, I've added the mapping to the function `enhancedEcommerceTrackProduct`.

This was the example in native GA:

``` javascript
ga("require", "ec");
ga("ec:addProduct", {
   "id": "81301",
   "name": "Xantech AC1 Controlled AC Outlet",
   "price": "78.55",
   "brand": "Xantech",
   "category": "AC1 Controlled AC Outlet",
   "variant": "white",
   "dimension3": "In stock - Ships Today", // stock status custom dim.
   "metric2": 5,                           // rating stars custom metric
   "quantity": 1 });
ga("ec:setAction", "add");
ga("send", "event", "Product", "Add to Cart", "Xantech AC1 Controlled AC Outlet");</s
```

This function is executed basically for every EE event so I'm attaching the CM and CE to the product payload which we set via `ec:addProduct`. 

I've left out mapping to `Clicked Promotion` and `Viewed Promotion` events since I cannot find any documentation on whether that is possible. It also doesn't map them for checkout steps EXCEPT for `Viewed Checkout Step` since that one adds product details.

FYI -- the GA offical [EE docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-promos) does not have this documented.

TODO: docs, UI testing (check if these events arrive.. I'm not seeing them in real time view but then again, I don't see any track events for other tests that are irrelevant so..)

Let me know what you think -- I'm going to check our GA account to see if these events made it.
