### PR TITLE
Override referrer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@ GA.prototype.page = function(page) {
   pageview.page = pagePath;
   pageview.title = pageTitle;
   pageview.location = props.url;
-  
+
   if (campaign.name) pageview.campaignName = campaign.name;
   if (campaign.source) pageview.campaignSource = campaign.source;
   if (campaign.medium) pageview.campaignMedium = campaign.medium;

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('includeSearch', false)
   .option('metrics', {})
   .option('nonInteraction', false)
+  .option('referrer', document.referrer)
   .option('sendUserId', false)
   .option('siteSpeedSampleRate', 1)
   .option('sampleRate', 100)
@@ -170,6 +171,7 @@ GA.prototype.page = function(page) {
   var pageview = {};
   var pagePath = path(props, this.options);
   var pageTitle = name || props.title;
+  var pageReferrer = props.referrer || opts.referrer;
   var track;
 
   // store for later
@@ -179,7 +181,7 @@ GA.prototype.page = function(page) {
   pageview.page = pagePath;
   pageview.title = pageTitle;
   pageview.location = props.url;
-
+  
   if (campaign.name) pageview.campaignName = campaign.name;
   if (campaign.source) pageview.campaignSource = campaign.source;
   if (campaign.medium) pageview.campaignMedium = campaign.medium;
@@ -191,7 +193,7 @@ GA.prototype.page = function(page) {
   if (len(custom)) window.ga('set', custom);
 
   // set
-  window.ga('set', { page: pagePath, title: pageTitle });
+  window.ga('set', { page: pagePath, title: pageTitle, referrer: pageReferrer });
 
   if (this.pageCalled) delete pageview.location;
 


### PR DESCRIPTION
As per #22 this PR should enable the documented way to override the page referrer, and otherwise defaults to the `document.referrer`, as does GA already
