### PR TITLE
add support for defensive referrer override

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,6 +170,7 @@ GA.prototype.page = function(page) {
   var pageview = {};
   var pagePath = path(props, this.options);
   var pageTitle = name || props.title;
+  var pageReferrer = page.referrer() || '';
   var track;
 
   // store for later
@@ -191,7 +192,12 @@ GA.prototype.page = function(page) {
   if (len(custom)) window.ga('set', custom);
 
   // set
-  window.ga('set', { page: pagePath, title: pageTitle });
+  var payload = {
+    page: pagePath,
+    title: pageTitle
+  };
+  if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
+  window.ga('set', payload);
 
   if (this.pageCalled) delete pageview.location;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -395,6 +395,24 @@ describe('Google Analytics', function() {
           analytics.assert(window.ga.args[2][0] === 'set');
           analytics.assert(window.ga.args[3][0] === 'send');
         });
+
+        it('should override referrer when manually set', function() {
+          analytics.page({ referrer: 'http://lifeofpablo.com' });
+          analytics.called(window.ga, 'set', {
+            page: window.location.pathname,
+            title: document.title,
+            referrer: 'http://lifeofpablo.com'
+          });
+        });
+
+        it('should not override referrer if not manually set', function() {
+          document.referrer = 'http://houseofballoons.com';
+          analytics.page();
+          analytics.called(window.ga, 'set', {
+            page: window.location.pathname,
+            title: document.title
+          });
+        });
       });
 
       describe('#identify', function() {


### PR DESCRIPTION
This is in response to #22.

This will take the defensive approach to overriding the `referrer` in the page object that we `set` using `window.ga`.

We should only override the referrer if the manually passed `referrer` property inside the `.page()` call is not the same as `document.referrer` so that we don't interfere with GA's default page tracking behavior.

@segment-integrations/core 
