### PR TITLE
Changed props.category to track.category()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -261,7 +261,7 @@ GA.prototype.track = function(track, options) {
 
   var payload = {
     eventAction: track.event(),
-    eventCategory: props.category || this._category || 'All',
+    eventCategory: track.category() || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || track.revenue()),
     nonInteraction: !!(props.nonInteraction || opts.nonInteraction)
@@ -424,7 +424,7 @@ GA.prototype.trackClassic = function(track, options) {
   var props = track.properties();
   var revenue = track.revenue();
   var event = track.event();
-  var category = this._category || props.category || 'All';
+  var category = this._category || track.category() || 'All';
   var label = props.label;
   var value = formatValue(revenue || props.value);
   var nonInteraction = !!(props.nonInteraction || opts.nonInteraction);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -455,6 +455,17 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should send an event and map category with a capital C', function() {
+          analytics.track('event', {Category: 'blah'});
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'blah',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: false
+          });
+        });
+
         it('should send an event with context', function() {
           analytics.track('event', {}, {
             campaign: {


### PR DESCRIPTION
This customer (https://segment.zendesk.com/agent/tickets/46706) complained that they pass `Category` with a capital C, and we don't properly map this to GA. They don't want to change all their casing to be lowercase. Facade methods do this for us, but we were just using `props.category` instead of `track.category()`.
