### PR TITLE
allow 0 as metric value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -539,7 +539,7 @@ function metrics(obj, data) {
     each(group, function(prop, key) {
       var value = dot(obj, prop) || obj[prop];
       if (is.bool(value)) value = value.toString();
-      if (value) ret[key] = value;
+      if (value || value === 0) ret[key] = value;
     });
   });
 


### PR DESCRIPTION
It'd be great if 0 were an acceptable value for custom metrics. We have a custom metric that we're setting to 0 in some track calls, and it's being dropped by Segment before sent to GA.