### PR TITLE
Allow user to override global nonInteraction flag

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.5.0 / 2017-04-27
+==================
+
+  * Allow user to override global nonInteraction setting
+
 2.4.1 / 2017-03-09
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -271,7 +271,8 @@ GA.prototype.track = function(track, options) {
     eventCategory: track.category() || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || track.revenue()),
-    nonInteraction: !!(props.nonInteraction || opts.nonInteraction)
+    // Allow users to override their nonInteraction integration setting for any single particluar event.
+    nonInteraction: props.nonInteraction !== undefined ? !!props.nonInteraction : !!opts.nonInteraction
   };
 
   if (campaign.name) payload.campaignName = campaign.name;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -603,6 +603,18 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should give precendence to a non-interaction option defined in the event props', function() {
+          ga.options.nonInteraction = true;
+          analytics.track('event', { nonInteraction: false });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: false
+          });
+        });
+
         it('should map custom dimensions & metrics using track.properties()', function() {
           ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
           ga.options.dimensions = { referrer: 'dimension2' };


### PR DESCRIPTION
PR allows users to explicitly override their global `nonInteraction` setting inside any particular event. Previously, if `this.settings.nonInteraction` was true, it was not possible to waive the option for any on