### PR TITLE
Remove excess send-pageview from addImpression events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.5.1 / 2017-05-05
+==================
+
+  * Remove excess pageview from addImpression-bound events
+
 2.5.0 / 2017-04-27
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -887,7 +887,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
     }
     window.ga('ec:addImpression', impressionObj);
   });
-  window.ga('send', 'pageview'); 
+  
   this.pushEnhancedEcommerce(track);
 };
 
@@ -927,7 +927,7 @@ GA.prototype.productListFilteredEnhanced = function(track) {
     }
     window.ga('ec:addImpression', impressionObj);
   });
-  window.ga('send', 'pageview'); 
+
   this.pushEnhancedEcommerce(track); 
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -943,7 +943,6 @@ describe('Google Analytics', function() {
             position: 1,
             variant: 'department:beauty,price:under::price:desc'
           }]);
-          console.log(window.ga.args[3]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', { nonInteraction: 1 }]);
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -902,7 +902,7 @@ describe('Google Analytics', function() {
               { product_id: '507f1f77bcf86cd799439011' }
             ]
           });
-          analytics.assert(window.ga.args.length === 5);
+          analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'USD']);
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:addImpression', {
             id: '507f1f77bcf86cd799439011',
@@ -910,8 +910,7 @@ describe('Google Analytics', function() {
             list: '1234',
             position: 1
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'pageview']);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'Product List Viewed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', { nonInteraction: 1 }]);
         });
 
         it('should send product impression data via product list filtered', function() {
@@ -935,7 +934,7 @@ describe('Google Analytics', function() {
               { product_id: '507f1f77bcf86cd799439011' }
             ]
           });
-          analytics.assert(window.ga.args.length === 5);
+          analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'USD']);
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:addImpression', {
             id: '507f1f77bcf86cd799439011',
@@ -944,8 +943,8 @@ describe('Google Analytics', function() {
             position: 1,
             variant: 'department:beauty,price:under::price:desc'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'pageview']);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'Product List Filtered', { nonInteraction: 1 }]);
+          console.log(window.ga.args[3]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', { nonInteraction: 1 }]);
         });
 
         it('should send product clicked data', function() {


### PR DESCRIPTION
In the past, I was sending an excess pageview along with the addImpression data. Our implementation already naturally sends this as an event later, so we were duplicating pagecalls. This fixes this, and gets parity with our server-side.

CC @ccnixon @hankim813 