### PR TITLE
Add id as custom dimension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,8 +141,15 @@ GA.prototype.initialize = function() {
   // in google analytics debugger
   if (opts.anonymizeIp) window.ga('set', 'anonymizeIp', true);
 
+  // initialize page with `id` appended to user's traits for client/server parity
+  // ensures `id` can be set as a custom dimension for all hits on the page
+  var userTraits = user.traits();
+  if (user.id()) {
+    userTraits.id = user.id();
+  }
+
   // custom dimensions & metrics
-  var custom = metrics(user.traits(), opts);
+  var custom = metrics(userTraits, opts);
   if (len(custom)) window.ga('set', custom);
 
   this.load('library', this.ready);
@@ -179,6 +186,11 @@ GA.prototype.page = function(page) {
   var pageTitle = name || props.title;
   var pageReferrer = page.referrer() || '';
   var track;
+
+  // add `id` to properties object
+  if (user.id()) {
+    props.id = user.id();
+  }
 
   // store for later
   // TODO: Why? Document this better
@@ -240,8 +252,14 @@ GA.prototype.identify = function(identify) {
     window.ga('set', 'userId', identify.userId());
   }
 
+  // add `id` to traits object
+  var userTraits = user.traits();
+  if (user.id()) {
+    userTraits.id = user.id();
+  }
+
   // Set dimensions
-  var custom = metrics(user.traits(), opts);
+  var custom = metrics(userTraits, opts);
   if (len(custom)) window.ga('set', custom);
 };
 
@@ -261,6 +279,11 @@ GA.prototype.track = function(track, options) {
   opts = defaults(opts, interfaceOpts);
   var props = track.properties();
   var campaign = track.proxy('context.campaign') || {};
+
+  // add `id` to properties object
+  if (user.id()) {
+    props.id = user.id();
+  }
 
   // custom dimensions & metrics
   var custom = metrics(props, interfaceOpts);
@@ -865,7 +888,7 @@ GA.prototype.promotionClickedEnhanced = function(track) {
  */
 
 GA.prototype.productListViewedEnhanced = function(track) {
-  var props = track.properties(); 
+  var props = track.properties();
   var products = track.products();
   this.loadEnhancedEcommerce(track);
   each(products, function(product) {
@@ -888,7 +911,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
     }
     window.ga('ec:addImpression', impressionObj);
   });
-  window.ga('send', 'pageview'); 
+  window.ga('send', 'pageview');
   this.pushEnhancedEcommerce(track);
 };
 
@@ -901,7 +924,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
  * @param {Track} track
  */
 
-GA.prototype.productListFilteredEnhanced = function(track) {  
+GA.prototype.productListFilteredEnhanced = function(track) {
   var props = track.properties();
   var products = track.products();
   props.filters = props.filters || [];
@@ -928,8 +951,8 @@ GA.prototype.productListFilteredEnhanced = function(track) {
     }
     window.ga('ec:addImpression', impressionObj);
   });
-  window.ga('send', 'pageview'); 
-  this.pushEnhancedEcommerce(track); 
+  window.ga('send', 'pageview');
+  this.pushEnhancedEcommerce(track);
 };
 
 


### PR DESCRIPTION
Adds `id` to traits/properties object of identify/page/track events so that customers can map `id` as a custom dimension out of the box. Creates parity with server-side integration.