### PR TITLE
Add setting to conditionally set or send custom metrics/dimensions of track events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.7.0 / 2017-05-31
+==================
+
+  * Add an interface option to stop the integration from setting custom metrics/dimensions to the global GA tracker object
+
 2.6.0 / 2017-05-10
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,7 @@ GA.prototype.page = function(page) {
 
   // custom dimensions, metrics and content groupings
   var custom = metrics(props, opts);
-  if (len(custom)) setOrSendProps(custom, payload, opts);
+  if (len(custom)) window.ga('set', custom);
   
   if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
   window.ga('set', payload);

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@ var Track = require('segmentio-facade').Track;
 var defaults = require('@ndhoule/defaults');
 var dot = require('obj-case');
 var each = require('component-each');
-var pick = require('@ndhoule/pick');
-var omit = require('omit');
 var integration = require('@segment/analytics.js-integration');
 var is = require('is');
 var len = require('object-component').length;
@@ -51,7 +49,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('enhancedLinkAttribution', false)
   .option('ignoredReferrers', null)
   .option('includeSearch', false)
-  .option('metricAndDimensionSettings', { setAllMappedProps: true, events: [] })
+  .option('setAllMappedProps', true)
   .option('metrics', {})
   .option('nonInteraction', false)
   .option('sendUserId', false)
@@ -205,15 +203,16 @@ GA.prototype.page = function(page) {
   if (campaign.content) pageview.campaignContent = campaign.content;
   if (campaign.term) pageview.campaignKeyword = campaign.term;
 
-  // custom dimensions, metrics and content groupings
-  var custom = metrics(props, opts);
-  if (len(custom)) window.ga('set', custom);
-
   // set
   var payload = {
     page: pagePath,
     title: pageTitle
   };
+
+  // custom dimensions, metrics and content groupings
+  var custom = metrics(props, opts);
+  if (len(custom)) setOrSendProps(custom, payload, opts);
+  
   if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
   window.ga('set', payload);
 
@@ -273,22 +272,6 @@ GA.prototype.track = function(track, options) {
   var props = track.properties();
   var campaign = track.proxy('context.campaign') || {};
 
-  // custom dimensions & metrics
-  var custom = metrics(props, interfaceOpts);
-  if (len(custom)) {
-    var setPropsAllEvents = interfaceOpts.metricAndDimensionSettings.setAllMappedProps;
-    var setPropsThisEvent = interfaceOpts.metricAndDimensionSettings.events.indexOf(track.event()) >= 0;
-
-    if (setPropsAllEvents || setPropsThisEvent) {
-      window.ga('set', custom);
-      custom = {};
-    } else if (contextOpts.propsToSet) {
-      var propsToSet = metrics(pick(contextOpts.propsToSet, props) || {}, interfaceOpts);
-      window.ga('set', propsToSet);
-      custom = omit(Object.keys(propsToSet), custom);
-    }
-  }
-
   var payload = {
     eventAction: track.event(),
     eventCategory: track.category() || this._category || 'All',
@@ -303,10 +286,10 @@ GA.prototype.track = function(track, options) {
   if (campaign.medium) payload.campaignMedium = campaign.medium;
   if (campaign.content) payload.campaignContent = campaign.content;
   if (campaign.term) payload.campaignKeyword = campaign.term;
-
-  each(custom, function(key, value) {
-    payload[key] = value;
-  });
+  
+  // custom dimensions & metrics
+  var custom = metrics(props, interfaceOpts);
+  if (len(custom)) setOrSendProps(custom, payload, interfaceOpts);
 
   window.ga('send', 'event', payload);
 };
@@ -1034,4 +1017,22 @@ function extractCheckoutOptions(props) {
 function createProductTrack(track, properties) {
   properties.currency = properties.currency || track.currency();
   return new Track({ properties: properties });
+}
+
+/**
+ * Either 'set' custom dimensions/props or add to the event payload.
+ *
+ * @api private
+ * @param {Object} custom
+ * @param {Object} payload
+ * @param {Object} options
+ */
+
+function setOrSendProps(custom, payload, options) {
+  if (options.setAllMappedProps) return window.ga('set', custom);
+  
+  // Add custom dimensions / metrics to payload
+  each(custom, function(key, value) {
+    payload[key] = value;
+  });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ var Track = require('segmentio-facade').Track;
 var defaults = require('@ndhoule/defaults');
 var dot = require('obj-case');
 var each = require('component-each');
+var pick = require('@ndhoule/pick');
+var omit = require('omit');
 var integration = require('@segment/analytics.js-integration');
 var is = require('is');
 var len = require('object-component').length;
@@ -49,6 +51,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('enhancedLinkAttribution', false)
   .option('ignoredReferrers', null)
   .option('includeSearch', false)
+  .option('metricAndDimensionSettings', { setAllMappedProps: true, events: [] })
   .option('metrics', {})
   .option('nonInteraction', false)
   .option('sendUserId', false)
@@ -272,7 +275,19 @@ GA.prototype.track = function(track, options) {
 
   // custom dimensions & metrics
   var custom = metrics(props, interfaceOpts);
-  if (len(custom)) window.ga('set', custom);
+  if (len(custom)) {
+    var setPropsAllEvents = interfaceOpts.metricAndDimensionSettings.setAllMappedProps;
+    var setPropsThisEvent = interfaceOpts.metricAndDimensionSettings.events.indexOf(track.event()) >= 0;
+
+    if (setPropsAllEvents || setPropsThisEvent) {
+      window.ga('set', custom);
+      custom = {};
+    } else if (contextOpts.propsToSet) {
+      var propsToSet = metrics(pick(contextOpts.propsToSet, props) || {}, interfaceOpts);
+      window.ga('set', propsToSet);
+      custom = omit(Object.keys(propsToSet), custom);
+    }
+  }
 
   var payload = {
     eventAction: track.event(),
@@ -288,6 +303,10 @@ GA.prototype.track = function(track, options) {
   if (campaign.medium) payload.campaignMedium = campaign.medium;
   if (campaign.content) payload.campaignContent = campaign.content;
   if (campaign.term) payload.campaignKeyword = campaign.term;
+
+  each(custom, function(key, value) {
+    payload[key] = value;
+  });
 
   window.ga('send', 'event', payload);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -289,7 +289,16 @@ GA.prototype.track = function(track, options) {
   
   // custom dimensions & metrics
   var custom = metrics(props, interfaceOpts);
-  if (len(custom)) setOrSendProps(custom, payload, interfaceOpts);
+  if (len(custom)) {
+    if (interfaceOpts.setAllMappedProps) {
+      window.ga('set', custom);
+    } else {
+      // Add custom dimensions / metrics to payload
+      each(custom, function(key, value) {
+        payload[key] = value;
+      });
+    }
+  }
 
   window.ga('send', 'event', payload);
 };
@@ -1017,22 +1026,4 @@ function extractCheckoutOptions(props) {
 function createProductTrack(track, properties) {
   properties.currency = properties.currency || track.currency();
   return new Track({ properties: properties });
-}
-
-/**
- * Either 'set' custom dimensions/props or add to the event payload.
- *
- * @api private
- * @param {Object} custom
- * @param {Object} payload
- * @param {Object} options
- */
-
-function setOrSendProps(custom, payload, options) {
-  if (options.setAllMappedProps) return window.ga('set', custom);
-  
-  // Add custom dimensions / metrics to payload
-  each(custom, function(key, value) {
-    payload[key] = value;
-  });
 }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-google-analytics#readme",
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
+    "@ndhoule/pick": "^2.0.0",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "obj-case": "^0.2.0",
     "object-component": "0.0.3",
+    "omit": "github:harrietgrace/omit",
     "reject": "0.0.1",
     "segmentio-facade": "^3.1.0",
     "use-https": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-google-analytics#readme",
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
-    "@ndhoule/pick": "^2.0.0",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "obj-case": "^0.2.0",
     "object-component": "0.0.3",
-    "omit": "github:harrietgrace/omit",
     "reject": "0.0.1",
     "segmentio-facade": "^3.1.0",
     "use-https": "^0.1.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,7 +43,7 @@ describe('Google Analytics', function() {
       .option('enhancedLinkAttribution', false)
       .option('ignoredReferrers', null)
       .option('includeSearch', false)
-      .option('metricAndDimensionSettings', { setAllMappedProps: true, events: [] })
+      .option('setAllMappedProps', true)
       .option('metrics', {})
       .option('nonInteraction', false)
       .option('sendUserId', false)
@@ -616,8 +616,8 @@ describe('Google Analytics', function() {
           });
         });
 
-        it('should map custom dimensions & metrics using track.properties() if trackAllEvents is true', function() {
-          ga.options.metricAndDimensionSettings = { setAllMappedProps: true, events: [] };
+        it('should map and set custom dimensions & metrics using track.properties() if setAllMappedProps is true', function() {
+          ga.options.setAllMappedProps = true;
           ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
           ga.options.dimensions = { referrer: 'dimension2' };
           analytics.track('Level Unlocked', { loadTime: '100', levelAchieved: '5', referrer: 'Google' });
@@ -629,8 +629,8 @@ describe('Google Analytics', function() {
           });
         });
 
-        it('should not map custom dimensions & metrics for unspecified events if trackAllEvents is false', function() {
-          ga.options.metricAndDimensionSettings = { trackAllEvents: false, events: ['Foobar'] };
+        it('should send but not set custom dimensions & metrics if setAllMappedProps is false', function() {
+          ga.options.setAllMappedProps = false;
           ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
           ga.options.dimensions = { referrer: 'dimension2' };
           analytics.track('Level Unlocked', { loadTime: '100', levelAchieved: '5', referrer: 'Google' });
@@ -640,23 +640,6 @@ describe('Google Analytics', function() {
             metric2: '5',
             dimension2: 'Google'
           });
-        });
-
-        it('should map custom dimensions & metrics from integration specific object for specified events if trackAllEvents is false', function() {
-          ga.options.metricAndDimensionSettings = { trackAllEvents: false, events: [] };
-          ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
-          ga.options.dimensions = { referrer: 'dimension2' };
-          analytics.track('Level Unlocked', { loadTime: '100', levelAchieved: '5', referrer: 'Google' }, {
-            integrations: {
-              'Google Analytics': {
-                propsToSet: ['loadTime']
-              }
-            }
-          });
-
-          analytics.called(window.ga, 'set', {
-            metric1: '100'
-          });
 
           analytics.called(window.ga, 'send', 'event', {
             eventCategory: 'All',
@@ -664,6 +647,7 @@ describe('Google Analytics', function() {
             eventLabel: undefined,
             eventValue: 0,
             nonInteraction: false,
+            metric1: '100',
             metric2: '5',
             dimension2: 'Google'
           });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -310,7 +310,7 @@ describe('Google Analytics', function() {
           });
         });
 
-        it('should map custom dimensions, metrics & content groupings using track.properties()', function() {
+        it('should map and set custom dimensions, metrics & content groupings using page.properties()', function() {
           ga.options.metrics = { score: 'metric1' };
           ga.options.dimensions = { author: 'dimension1', postType: 'dimension2' };
           ga.options.contentGroupings = { section: 'contentGrouping1' };


### PR DESCRIPTION
PR adds a setting to either "set" the custom dimensions / metrics associated with a `track` event to the global GA tracker OR just send them as properties of the custom event. Previously we were by default setting all props.

See here for more info on this functionality: https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets