### PR TITLE
Do not set custom dimensions/metrics if feature is disabled

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.8.0 / 2017-06-13
+==================
+
+  * Extend previous change to apply for custom properties of `page` events.
+
 2.7.0 / 2017-05-31
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,16 @@ GA.prototype.page = function(page) {
 
   // custom dimensions, metrics and content groupings
   var custom = metrics(props, opts);
-  if (len(custom)) window.ga('set', custom);
+  if (len(custom)) {
+    if (opts.setAllMappedProps) {
+      window.ga('set', custom);
+    } else {
+      // Add custom dimensions / metrics to pageview payload
+      each(custom, function(key, value) {
+        pageview[key] = value;
+      });
+    }
+  }
   
   if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
   window.ga('set', payload);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -277,6 +277,19 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should not set custom dimensions/metrics if settings.setAllMappedProps is false', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
+          ga.options.dimensions = { referrer: 'dimension2' };
+          analytics.page('Page Viewed', { loadTime: '100', levelAchieved: '5', referrer: 'Google' });
+
+          analytics.didNotCall(window.ga, 'set', {
+            metric1: '100',
+            metric2: '5',
+            dimension2: 'Google'
+          });
+        });
+
         it('should send the query if its included', function() {
           ga.options.includeSearch = true;
           analytics.page('category', 'name', { url: 'url', path: '/path', search: '?q=1' });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -280,10 +280,19 @@ describe('Google Analytics', function() {
         it('should not set custom dimensions/metrics if settings.setAllMappedProps is false', function() {
           ga.options.setAllMappedProps = false;
           ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
-          ga.options.dimensions = { referrer: 'dimension2' };
-          analytics.page('Page Viewed', { loadTime: '100', levelAchieved: '5', referrer: 'Google' });
-
+          ga.options.dimensions = { company: 'dimension2' };
+          analytics.page('Page Viewed', { loadTime: '100', levelAchieved: '5', company: 'Google' });
+          
           analytics.didNotCall(window.ga, 'set', {
+            metric1: '100',
+            metric2: '5',
+            dimension2: 'Google'
+          });
+          
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: window.location.pathname,
+            title: 'Page Viewed',
+            location: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search,
             metric1: '100',
             metric2: '5',
             dimension2: 'Google'


### PR DESCRIPTION
PR adds the functionality of this [pr](https://github.com/segment-integrations/analytics.js-integration-google-analytics/pull/56) to `page` events. Addresses this Jira issue: https://segment.atlassian.net/browse/EPD-2957