### PR TITLE
PLATFORM-36: add custom name to tracker

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.9.0 / 2017-24-08
+==================
+
+  * Use custom name for tracker rather than default unnamed
+
 2.8.0 / 2017-06-13
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ GA.prototype.initialize = function() {
     siteSpeedSampleRate: opts.siteSpeedSampleRate,
     sampleRate: opts.sampleRate,
     allowLinker: true
-  });
+  }, 'segmentTrackerGA');
 
   if (opts.optimize) window.ga('require', opts.optimize);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -125,7 +125,7 @@ describe('Google Analytics', function() {
           if (window.location.hostname !== 'localhost') expectedOpts.cookieDomain = 'auto';
           analytics.initialize();
           analytics.page();
-          analytics.deepEqual(toArray(window.ga.q[0]), ['create', settings.trackingId, expectedOpts]);
+          analytics.deepEqual(toArray(window.ga.q[0]), ['create', settings.trackingId, expectedOpts, 'segmentTrackerGA']);
         });
 
         it('should call window.ga.require for optimize if enabled', function() {


### PR DESCRIPTION
Use a custom name when creating the GA tracker instead of the default unnamed.

https://segment.atlassian.net/browse/PLATFORM-36