### PR TITLE
Update/ee custom dimensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.10.0 / 2018-02-06
+=================
+
+* Support custom dimensions for enhanced ecommerce events.
+
 2.9.6 / 2017-11-28
 =================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var len = require('object-component').length;
 var push = require('global-queue')('_gaq');
 var reject = require('reject');
 var useHttps = require('use-https');
+var extend = require('extend');
 var user;
 
 /**
@@ -198,6 +199,7 @@ GA.prototype.page = function(page) {
   var pagePath = path(props, this.options);
   var pageTitle = name || props.title;
   var pageReferrer = page.referrer() || '';
+  var self = this;
   var track;
 
   // store for later
@@ -220,18 +222,7 @@ GA.prototype.page = function(page) {
     title: pageTitle
   };
 
-  // custom dimensions, metrics and content groupings
-  var custom = metrics(props, opts);
-  if (len(custom)) {
-    if (opts.setAllMappedProps) {
-      window.ga(this._trackerName + 'set', custom);
-    } else {
-      // Add custom dimensions / metrics to pageview payload
-      each(custom, function(key, value) {
-        pageview[key] = value;
-      });
-    }
-  }
+  pageview = extend(pageview, setCustomDimenionsAndMetrics(props, opts, self._trackerName));
 
   if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
   window.ga(this._trackerName + 'set', payload);
@@ -291,6 +282,7 @@ GA.prototype.track = function(track, options) {
   opts = defaults(opts, interfaceOpts);
   var props = track.properties();
   var campaign = track.proxy('context.campaign') || {};
+  var self = this;
 
   var payload = {
     eventAction: track.event(),
@@ -307,18 +299,7 @@ GA.prototype.track = function(track, options) {
   if (campaign.content) payload.campaignContent = campaign.content;
   if (campaign.term) payload.campaignKeyword = campaign.term;
 
-  // custom dimensions & metrics
-  var custom = metrics(props, interfaceOpts);
-  if (len(custom)) {
-    if (interfaceOpts.setAllMappedProps) {
-      window.ga(this._trackerName + 'set', custom);
-    } else {
-      // Add custom dimensions / metrics to payload
-      each(custom, function(key, value) {
-        payload[key] = value;
-      });
-    }
-  }
+  payload = extend(payload, setCustomDimenionsAndMetrics(props, interfaceOpts, self._trackerName));
 
   window.ga(this._trackerName + 'send', 'event', payload);
 };
@@ -540,6 +521,31 @@ function path(properties, options) {
   var str = properties.path;
   if (options.includeSearch && properties.search) str += properties.search;
   return str;
+}
+
+/**
+ * Set custom dimensions and metrics
+ *
+ * @param {Properties} props
+ * @param {Options} opts
+ * @param {String} trackerName
+ * @return {Object}
+ */
+
+function setCustomDimenionsAndMetrics(props, opts, trackerName) {
+  var ret = {};
+  var custom = metrics(props, opts);
+  if (len(custom)) {
+    if (opts.setAllMappedProps) {
+      window.ga(trackerName + 'set', custom);
+    } else {
+      // Add custom dimensions / metrics to event payload
+      each(custom, function(key, value) {
+        ret[key] = value;
+      });
+      return ret;
+    }
+  }
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -932,6 +932,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
   var props = track.properties();
   var products = track.products();
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   each(products, function(product) {
@@ -955,7 +956,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
     window.ga(self._trackerName + 'ec:addImpression', impressionObj);
   });
 
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -804,10 +804,11 @@ GA.prototype.orderRefundedEnhanced = function(track) {
 
 GA.prototype.productAddedEnhanced = function(track) {
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   enhancedEcommerceProductAction(track, 'add', null, self._trackerName);
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -842,12 +842,13 @@ GA.prototype.productViewedEnhanced = function(track) {
   var props = track.properties();
   var data = {};
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   // list property is optional
   if (props.list) data.list = props.list;
   enhancedEcommerceProductAction(track, 'detail', data, self._trackerName);
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -630,10 +630,8 @@ GA.prototype.pushEnhancedEcommerce = function(track, opts, trackerName) {
     track.category() || 'EnhancedEcommerce',
     track.event() || 'Action not defined',
     track.properties().label,
-    { nonInteraction: 1 }
+    extend({ nonInteraction: 1 }, setCustomDimenionsAndMetrics(track.properties(), opts, trackerName))
   ]);
-  args[5] = extend(args[5], setCustomDimenionsAndMetrics(track.properties(), opts, trackerName));
-  console.log('args', args);
   window.ga.apply(window, args);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -864,12 +864,13 @@ GA.prototype.productClickedEnhanced = function(track) {
   var props = track.properties();
   var data = {};
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   // list property is optional
   if (props.list) data.list = props.list;
   enhancedEcommerceProductAction(track, 'click', data, self._trackerName);
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -822,10 +822,11 @@ GA.prototype.productAddedEnhanced = function(track) {
 
 GA.prototype.productRemovedEnhanced = function(track) {
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   enhancedEcommerceProductAction(track, 'remove', null, self._trackerName);
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -976,6 +976,7 @@ GA.prototype.productListFilteredEnhanced = function(track) {
   var filters = props.filters.map(function(obj) { return obj.type + ':' + obj.value;}).join();
   var sorts = props.sorts.map(function(obj) { return obj.type + ':' + obj.value;}).join();
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   each(products, function(product) {
@@ -998,7 +999,7 @@ GA.prototype.productListFilteredEnhanced = function(track) {
     window.ga(self._trackerName + 'ec:addImpression', impressionObj);
   });
 
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -620,7 +620,7 @@ GA.prototype.loadEnhancedEcommerce = function(track) {
  * @param {Track} track
  */
 
-GA.prototype.pushEnhancedEcommerce = function(track) {
+GA.prototype.pushEnhancedEcommerce = function(track, opts, trackerName) {
   var self = this;
   // Send a custom non-interaction event to ensure all EE data is pushed.
   // Without doing this we'd need to require page display after setting EE data.
@@ -632,6 +632,8 @@ GA.prototype.pushEnhancedEcommerce = function(track) {
     track.properties().label,
     { nonInteraction: 1 }
   ]);
+  args[5] = extend(args[5], setCustomDimenionsAndMetrics(track.properties(), opts, trackerName));
+  console.log('args', args);
   window.ga.apply(window, args);
 };
 
@@ -733,6 +735,7 @@ GA.prototype.orderCompletedEnhanced = function(track) {
   var orderId = track.orderId();
   var products = track.products();
   var props = track.properties();
+  var opts = this.options;
   var self = this;
 
   // orderId is required.
@@ -754,7 +757,7 @@ GA.prototype.orderCompletedEnhanced = function(track) {
     coupon: track.coupon()
   });
 
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -885,6 +885,7 @@ GA.prototype.productClickedEnhanced = function(track) {
 GA.prototype.promotionViewedEnhanced = function(track) {
   var props = track.properties();
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   window.ga(self._trackerName + 'ec:addPromo', {
@@ -893,7 +894,7 @@ GA.prototype.promotionViewedEnhanced = function(track) {
     creative: props.creative,
     position: props.position
   });
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**
@@ -908,6 +909,7 @@ GA.prototype.promotionViewedEnhanced = function(track) {
 GA.prototype.promotionClickedEnhanced = function(track) {
   var props = track.properties();
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
   window.ga(self._trackerName + 'ec:addPromo', {
@@ -917,7 +919,7 @@ GA.prototype.promotionClickedEnhanced = function(track) {
     position: props.position
   });
   window.ga(self._trackerName + 'ec:setAction', 'promo_click', {});
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -677,6 +677,7 @@ GA.prototype.checkoutStepViewedEnhanced = function(track) {
   var props = track.properties();
   var options = extractCheckoutOptions(props);
   var self = this;
+  var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
 
@@ -689,7 +690,7 @@ GA.prototype.checkoutStepViewedEnhanced = function(track) {
     option: options || undefined
   });
 
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**
@@ -771,6 +772,7 @@ GA.prototype.orderRefundedEnhanced = function(track) {
   var orderId = track.orderId();
   var products = track.products();
   var self = this;
+  var opts = this.options;
 
   // orderId is required.
   if (!orderId) return;
@@ -790,7 +792,7 @@ GA.prototype.orderRefundedEnhanced = function(track) {
     id: orderId
   });
 
-  this.pushEnhancedEcommerce(track);
+  this.pushEnhancedEcommerce(track, opts, self._trackerName);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.9.6",
+  "version": "2.10.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
+    "extend": "^3.0.1",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "obj-case": "^0.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -942,13 +942,19 @@ describe('Google Analytics', function() {
         });
 
         it('should send product removed data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('product removed', {
             currency: 'CAD',
             quantity: 1,
             price: 24.75,
             name: 'my product',
             category: 'cat 1',
-            sku: 'p-298'
+            sku: 'p-298', 
+            testDimension: 'true', 
+            testMetric: 'true'
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -964,7 +970,11 @@ describe('Google Analytics', function() {
             currency: 'CAD'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'remove', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product removed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product removed', {
+            dimension1: 'true', 
+            metric1: 'true', 
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send product viewed data', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1047,6 +1047,10 @@ describe('Google Analytics', function() {
 
         it('should send product impression data via product list filtered', function() {
           // If using addImpression ever becomes optional, will need to add a setting modification here.
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('Product List Filtered', {
             category: 'cat 1',
             list_id: '1234',
@@ -1064,7 +1068,9 @@ describe('Google Analytics', function() {
             }],
             products: [
               { product_id: '507f1f77bcf86cd799439011' }
-            ]
+            ],
+            testDimension: true,
+            testMetric: true
           });
           analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'USD']);
@@ -1075,7 +1081,11 @@ describe('Google Analytics', function() {
             position: 1,
             variant: 'department:beauty,price:under::price:desc'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send product clicked data', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -879,13 +879,19 @@ describe('Google Analytics', function() {
         });
 
         it('should send product added data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('product added', {
             currency: 'CAD',
             quantity: 1,
             price: 24.75,
             name: 'my product',
             category: 'cat 1',
-            sku: 'p-298'
+            sku: 'p-298',
+            testDimension: 'true', 
+            testMetric: 'true'
           });
           
           analytics.assert(window.ga.args.length === 5);
@@ -901,7 +907,11 @@ describe('Google Analytics', function() {
             currency: 'CAD'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'add', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', { 
+            dimension1: 'true',
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send send label tracking enhanced ecommerce events with Univeral Analytics', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1017,12 +1017,18 @@ describe('Google Analytics', function() {
 
         it('should send product impression data via product list viewed', function() {
           // If using addImpression ever becomes optional, will need to add a setting modification here.
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('Product List Viewed', {
             category: 'cat 1',
             list_id: '1234',
             products: [
               { product_id: '507f1f77bcf86cd799439011' }
-            ]
+            ],
+            testDimension: 'true', 
+            testMetric: 'true'
           });
           analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'USD']);
@@ -1032,7 +1038,11 @@ describe('Google Analytics', function() {
             list: '1234',
             position: 1
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send product impression data via product list filtered', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1089,6 +1089,10 @@ describe('Google Analytics', function() {
         });
 
         it('should send product clicked data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('product clicked', {
             currency: 'CAD',
             quantity: 1,
@@ -1096,7 +1100,9 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            list: 'search results'
+            list: 'search results', 
+            testDimension: true,
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -1112,7 +1118,11 @@ describe('Google Analytics', function() {
             currency: 'CAD'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'click', { list: 'search results' }]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product clicked', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product clicked', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send promotion viewed data', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1381,6 +1381,10 @@ describe('Google Analytics', function() {
         });
 
         it('should send order completed data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('order completed', {
             orderId: '780bc55',
             total: 99.9,
@@ -1389,6 +1393,8 @@ describe('Google Analytics', function() {
             currency: 'CAD',
             coupon: 'coupon',
             affiliation: 'affiliation',
+            testDimension: true,
+            testMetric: true,
             products: [{
               quantity: 1,
               price: 24.75,
@@ -1435,7 +1441,11 @@ describe('Google Analytics', function() {
             shipping: 13.99,
             coupon: 'coupon'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order completed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order completed', { 
+            nonInteraction: 1, 
+            metric1: 'true', 
+            dimension1: 'true' 
+          }]);
         });
 
         it('should add coupon to product level in order completed', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1156,12 +1156,18 @@ describe('Google Analytics', function() {
         });
 
         it('should send promotion clicked data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('promotion clicked', {
             currency: 'CAD',
             promotion_id: 'PROMO_1234',
             name: 'Summer Sale',
             creative: 'summer_banner2',
-            position: 'banner_slot1'
+            position: 'banner_slot1', 
+            testDimension: true,
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -1173,7 +1179,11 @@ describe('Google Analytics', function() {
             position: 'banner_slot1'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'promo_click', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'EnhancedEcommerce', 'promotion clicked', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'EnhancedEcommerce', 'promotion clicked', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send order started data', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -890,8 +890,8 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            testDimension: 'true', 
-            testMetric: 'true'
+            testDimension: true, 
+            testMetric: true
           });
           
           analytics.assert(window.ga.args.length === 5);
@@ -953,8 +953,8 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298', 
-            testDimension: 'true', 
-            testMetric: 'true'
+            testDimension: true, 
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -990,8 +990,8 @@ describe('Google Analytics', function() {
             category: 'cat 1',
             sku: 'p-298',
             list: 'Apparel Gallery', 
-            testDimension: 'true', 
-            testMetric: 'true'
+            testDimension: true, 
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -1027,8 +1027,8 @@ describe('Google Analytics', function() {
             products: [
               { product_id: '507f1f77bcf86cd799439011' }
             ],
-            testDimension: 'true', 
-            testMetric: 'true'
+            testDimension: true, 
+            testMetric: true
           });
           analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'USD']);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1126,12 +1126,18 @@ describe('Google Analytics', function() {
         });
 
         it('should send promotion viewed data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('promotion viewed', {
             currency: 'CAD',
             promotion_id: 'PROMO_1234',
             name: 'Summer Sale',
             creative: 'summer_banner2',
-            position: 'banner_slot1'
+            position: 'banner_slot1', 
+            testDimension: true,
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 4);
@@ -1142,7 +1148,11 @@ describe('Google Analytics', function() {
             creative: 'summer_banner2',
             position: 'banner_slot1'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'promotion viewed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'promotion viewed', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send promotion clicked data', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1177,6 +1177,10 @@ describe('Google Analytics', function() {
         });
 
         it('should send order started data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('checkout started', {
             currency: 'CAD',
             products: [{
@@ -1191,7 +1195,9 @@ describe('Google Analytics', function() {
               sku: 'p-299'
             }],
             step: 1,
-            paymentMethod: 'Visa'
+            paymentMethod: 'Visa', 
+            testDimension: true,
+            testMetric: true
           });
           analytics.assert(window.ga.args.length === 6);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
@@ -1219,10 +1225,18 @@ describe('Google Analytics', function() {
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'checkout started', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'checkout started', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send order updated data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('order updated', {
             currency: 'CAD',
             products: [{
@@ -1239,7 +1253,9 @@ describe('Google Analytics', function() {
               sku: 'p-299'
             }],
             step: 1,
-            paymentMethod: 'Visa'
+            paymentMethod: 'Visa', 
+            testDimension: true,
+            testMetric: true
           });
           analytics.assert(window.ga.args.length === 6);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
@@ -1267,7 +1283,11 @@ describe('Google Analytics', function() {
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order updated', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order updated', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send checkout step viewed data', function() {
@@ -1488,16 +1508,28 @@ describe('Google Analytics', function() {
         });
 
         it('should send full order refunded data', function() {
-          analytics.track('order refunded', { orderId: '780bc55' });
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
+          analytics.track('order refunded', { orderId: '780bc55', testDimension: true, testMetric: true });
 
           analytics.assert(window.ga.args.length === 4);
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
 
         it('should send partial order refunded data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('order refunded', {
             orderId: '780bc55',
             products: [{
@@ -1506,7 +1538,9 @@ describe('Google Analytics', function() {
             }, {
               quantity: 2,
               sku: 'p-299'
-            }]
+            }], 
+            testDimension: true,
+            testMetric: true
           });
 
           analytics.assert(window.ga.args.length === 6);
@@ -1521,7 +1555,11 @@ describe('Google Analytics', function() {
           analytics.deepEqual(toArray(window.ga.args[4]), ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { 
+            dimension1: 'true',
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -978,6 +978,10 @@ describe('Google Analytics', function() {
         });
 
         it('should send product viewed data', function() {
+          ga.options.setAllMappedProps = false;
+          ga.options.dimensions = { testDimension: 'dimension1' };
+          ga.options.metrics = { testMetric: 'metric1' };
+
           analytics.track('product viewed', {
             currency: 'CAD',
             quantity: 1,
@@ -985,7 +989,9 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            list: 'Apparel Gallery'
+            list: 'Apparel Gallery', 
+            testDimension: 'true', 
+            testMetric: 'true'
           });
 
           analytics.assert(window.ga.args.length === 5);
@@ -1001,7 +1007,11 @@ describe('Google Analytics', function() {
             currency: 'CAD'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'detail', { list: 'Apparel Gallery' }]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product viewed', { nonInteraction: 1 }]);
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product viewed', { 
+            dimension1: 'true', 
+            metric1: 'true',
+            nonInteraction: 1 
+          }]);
           analytics.assert(window.ga.args[1][0] === 'set');
         });
 


### PR DESCRIPTION
- Sends custom dimensions, metrics and content groupings with enhanced ecommerce events.
- The only events I know of that are actually *useful* to send custom dimensions to are "Order Completed", "Product List Viewed" and "Product List Filtered." That said, I think it may be beneficial to pass along CDs to all our EE events just in case the customer (or their contractor) knows to look somewhere I don't for all these custom dimensions.