### PR TITLE
Fix the Checkout Step Completed event to correctly handle options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -707,15 +707,14 @@ GA.prototype.checkoutStepCompletedEnhanced = function(track) {
   var options = extractCheckoutOptions(props);
   var self = this;
 
-  // Only send an event if we have step and options to update
-  if (!props.step || !options) return;
-
   this.loadEnhancedEcommerce(track);
 
-  window.ga(self._trackerName + 'ec:setAction', 'checkout_option', {
-    step: props.step || 1,
-    option: options
-  });
+  var checkoutOption = {
+    step: props.step || 1
+  };
+  if (options) checkoutOption.option = options;
+
+  window.ga(self._trackerName + 'ec:setAction', 'checkout_option', checkoutOption);
 
   window.ga(self._trackerName + 'send', 'event', 'Checkout', 'Option');
 };
@@ -1069,8 +1068,8 @@ function enhancedEcommerceProductAction(track, action, data, trackerName, opts) 
 
 function extractCheckoutOptions(props) {
   var options = [
-    props.paymentMethod,
-    props.shippingMethod
+    props.payment_method,
+    props.shipping_method
   ];
 
   // Remove all nulls, and join with commas.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -890,11 +890,11 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            testDimension: true, 
+            testDimension: true,
             testMetric: true,
             position: 4
           });
-          
+
           analytics.assert(window.ga.args.length === 5);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:addProduct', {
@@ -906,15 +906,15 @@ describe('Google Analytics', function() {
             brand: undefined,
             variant: undefined,
             currency: 'CAD',
-            metric1: 'true', 
+            metric1: 'true',
             dimension1: 'true',
             position: 4
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'add', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', { 
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', {
             dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -930,11 +930,11 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            testDimension: true, 
+            testDimension: true,
             testMetric: true,
             position: 4.5
           });
-          
+
           analytics.assert(window.ga.args.length === 5);
           analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:addProduct', {
@@ -946,15 +946,15 @@ describe('Google Analytics', function() {
             brand: undefined,
             variant: undefined,
             currency: 'CAD',
-            metric1: 'true', 
+            metric1: 'true',
             dimension1: 'true',
             position: 5
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'add', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', { 
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product added', {
             dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -996,8 +996,8 @@ describe('Google Analytics', function() {
             price: 24.75,
             name: 'my product',
             category: 'cat 1',
-            sku: 'p-298', 
-            testDimension: true, 
+            sku: 'p-298',
+            testDimension: true,
             testMetric: true
           });
 
@@ -1012,14 +1012,14 @@ describe('Google Analytics', function() {
             brand: undefined,
             variant: undefined,
             currency: 'CAD',
-            metric1: 'true', 
+            metric1: 'true',
             dimension1: 'true'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'remove', {}]);
           analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product removed', {
-            dimension1: 'true', 
-            metric1: 'true', 
-            nonInteraction: 1 
+            dimension1: 'true',
+            metric1: 'true',
+            nonInteraction: 1
           }]);
         });
 
@@ -1035,8 +1035,8 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            list: 'Apparel Gallery', 
-            testDimension: true, 
+            list: 'Apparel Gallery',
+            testDimension: true,
             testMetric: true
           });
 
@@ -1055,10 +1055,10 @@ describe('Google Analytics', function() {
             dimension1: 'true'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'detail', { list: 'Apparel Gallery' }]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product viewed', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product viewed', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
           analytics.assert(window.ga.args[1][0] === 'set');
         });
@@ -1075,7 +1075,7 @@ describe('Google Analytics', function() {
             products: [
               { product_id: '507f1f77bcf86cd799439011' }
             ],
-            testDimension: true, 
+            testDimension: true,
             testMetric: true
           });
           analytics.assert(window.ga.args.length === 4);
@@ -1086,10 +1086,10 @@ describe('Google Analytics', function() {
             list: '1234',
             position: 1
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1129,10 +1129,10 @@ describe('Google Analytics', function() {
             position: 1,
             variant: 'department:beauty,price:under::price:desc'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1148,7 +1148,7 @@ describe('Google Analytics', function() {
             name: 'my product',
             category: 'cat 1',
             sku: 'p-298',
-            list: 'search results', 
+            list: 'search results',
             testDimension: true,
             testMetric: true
           });
@@ -1163,15 +1163,15 @@ describe('Google Analytics', function() {
             price: 24.75,
             brand: undefined,
             variant: undefined,
-            currency: 'CAD', 
-            metric1: 'true', 
+            currency: 'CAD',
+            metric1: 'true',
             dimension1: 'true'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'click', { list: 'search results' }]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product clicked', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'cat 1', 'product clicked', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1185,7 +1185,7 @@ describe('Google Analytics', function() {
             promotion_id: 'PROMO_1234',
             name: 'Summer Sale',
             creative: 'summer_banner2',
-            position: 'banner_slot1', 
+            position: 'banner_slot1',
             testDimension: true,
             testMetric: true
           });
@@ -1198,10 +1198,10 @@ describe('Google Analytics', function() {
             creative: 'summer_banner2',
             position: 'banner_slot1'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'promotion viewed', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'promotion viewed', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1215,7 +1215,7 @@ describe('Google Analytics', function() {
             promotion_id: 'PROMO_1234',
             name: 'Summer Sale',
             creative: 'summer_banner2',
-            position: 'banner_slot1', 
+            position: 'banner_slot1',
             testDimension: true,
             testMetric: true
           });
@@ -1229,10 +1229,10 @@ describe('Google Analytics', function() {
             position: 'banner_slot1'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['ec:setAction', 'promo_click', {}]);
-          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'EnhancedEcommerce', 'promotion clicked', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[4]), ['send', 'event', 'EnhancedEcommerce', 'promotion clicked', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1255,7 +1255,7 @@ describe('Google Analytics', function() {
               sku: 'p-299'
             }],
             step: 1,
-            paymentMethod: 'Visa', 
+            payment_method: 'Visa',
             testDimension: true,
             testMetric: true
           });
@@ -1285,10 +1285,10 @@ describe('Google Analytics', function() {
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'checkout started', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'checkout started', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1313,7 +1313,7 @@ describe('Google Analytics', function() {
               sku: 'p-299'
             }],
             step: 1,
-            paymentMethod: 'Visa', 
+            payment_method: 'Visa',
             testDimension: true,
             testMetric: true
           });
@@ -1343,10 +1343,10 @@ describe('Google Analytics', function() {
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order updated', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order updated', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1369,7 +1369,7 @@ describe('Google Analytics', function() {
           analytics.track('checkout step completed', {
             currency: 'CAD',
             step: 2,
-            shippingMethod: 'FedEx'
+            shipping_method: 'FedEx'
           });
 
           analytics.assert(window.ga.args.length === 4);
@@ -1385,8 +1385,8 @@ describe('Google Analytics', function() {
           analytics.track('checkout step completed', {
             currency: 'CAD',
             step: 2,
-            paymentMethod: 'Visa',
-            shippingMethod: 'FedEx'
+            payment_method: 'Visa',
+            shipping_method: 'FedEx'
           });
 
           analytics.assert(window.ga.args.length === 4);
@@ -1398,22 +1398,33 @@ describe('Google Analytics', function() {
           analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'Checkout', 'Option']);
         });
 
-        it('should not send checkout step completed data without a step', function() {
+        it('should send checkout step completed data without a step', function() {
           analytics.track('checkout step completed', {
             currency: 'CAD',
-            shippingMethod: 'FedEx'
+            shipping_method: 'FedEx'
           });
 
-          analytics.assert(window.ga.args.length === 0);
+          analytics.assert(window.ga.args.length === 4);
+          analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
+          analytics.deepEqual(toArray(window.ga.args[2]), ['ec:setAction', 'checkout_option', {
+            step: 1,
+            option: 'FedEx'
+          }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'Checkout', 'Option']);
         });
 
-        it('should not send checkout step completed data without an option', function() {
+        it('should send checkout step completed data without an option', function() {
           analytics.track('checkout step completed', {
             currency: 'CAD',
-            step: 2
+            step: '2'
           });
 
-          analytics.assert(window.ga.args.length === 0);
+          analytics.assert(window.ga.args.length === 4);
+          analytics.deepEqual(toArray(window.ga.args[1]), ['set', '&cu', 'CAD']);
+          analytics.deepEqual(toArray(window.ga.args[2]), ['ec:setAction', 'checkout_option', {
+            step: 2
+          }]);
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'Checkout', 'Option']);
         });
 
         it('should send simple order completed data', function() {
@@ -1432,9 +1443,9 @@ describe('Google Analytics', function() {
 
         it('should send order completed data', function() {
           ga.options.setAllMappedProps = false;
-          ga.options.dimensions = { 
-            testDimension: 'dimension1', 
-            productDimension: 'dimension2' 
+          ga.options.dimensions = {
+            testDimension: 'dimension1',
+            productDimension: 'dimension2'
           };
           ga.options.metrics = { testMetric: 'metric1' };
 
@@ -1498,10 +1509,10 @@ describe('Google Analytics', function() {
             shipping: 13.99,
             coupon: 'coupon'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order completed', { 
-            nonInteraction: 1, 
-            metric1: 'true', 
-            dimension1: 'true' 
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order completed', {
+            nonInteraction: 1,
+            metric1: 'true',
+            dimension1: 'true'
           }]);
         });
 
@@ -1595,10 +1606,10 @@ describe('Google Analytics', function() {
           analytics.deepEqual(toArray(window.ga.args[2]), ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { 
-            dimension1: 'true', 
+          analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', {
+            dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
 
@@ -1615,7 +1626,7 @@ describe('Google Analytics', function() {
             }, {
               quantity: 2,
               sku: 'p-299'
-            }], 
+            }],
             testDimension: true,
             testMetric: true
           });
@@ -1632,10 +1643,10 @@ describe('Google Analytics', function() {
           analytics.deepEqual(toArray(window.ga.args[4]), ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', { 
+          analytics.deepEqual(toArray(window.ga.args[5]), ['send', 'event', 'EnhancedEcommerce', 'order refunded', {
             dimension1: 'true',
             metric1: 'true',
-            nonInteraction: 1 
+            nonInteraction: 1
           }]);
         });
       });


### PR DESCRIPTION
The `Checkout Step Completed` event will refuse to send unless you send both a step _and_ an option value of some sort (`paymentMethod` or `shippingMethod`), when the documentation says you can send it without either one (and `step` will default to `1`, which it did but was incorrectly filtered away). This PR fixes both of those issues as well as renames `paymentMethod` and `shippingMethod` to their documentation-specified names of `payment_method` and `shipping_method`. This PR does not add any additional supported option values (though they are supported in GA).