### PR TITLE
[DEST-414] Map custom product dimensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -940,6 +940,7 @@ GA.prototype.productListViewedEnhanced = function(track) {
   var opts = this.options;
 
   this.loadEnhancedEcommerce(track);
+
   each(products, function(product) {
     // If we don't have an ID/SKU or name, return - GA will reject the impression.
     var item = new Track({ properties: product });
@@ -954,6 +955,8 @@ GA.prototype.productListViewedEnhanced = function(track) {
       price: item.price(),
       position: products.map(function(x) { return x.product_id; }).indexOf(item.productId()) + 1
     };
+
+    impressionObj = extend(impressionObj, metrics(item.properties(), opts));
 
     for (var prop in impressionObj) {
       if (impressionObj[prop] === undefined) delete impressionObj[prop];
@@ -998,6 +1001,9 @@ GA.prototype.productListFilteredEnhanced = function(track) {
       price: item.price(),
       position: products.map(function(x) { return x.product_id; }).indexOf(item.productId()) + 1
     };
+
+    impressionObj = extend(impressionObj, metrics(item.properties(), opts));
+
     for (var prop in impressionObj) {
       if (impressionObj[prop] === undefined) delete impressionObj[prop];
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1087,14 +1087,14 @@ describe('Google Analytics', function() {
         it('should send product impression data via product list viewed', function() {
           // If using addImpression ever becomes optional, will need to add a setting modification here.
           ga.options.setAllMappedProps = false;
-          ga.options.dimensions = { testDimension: 'dimension1' };
-          ga.options.metrics = { testMetric: 'metric1' };
+          ga.options.dimensions = { testDimension: 'dimension1', productDimension: 'dimension2' };
+          ga.options.metrics = { testMetric: 'metric1', productMetric: 'metric2' };
 
           analytics.track('Product List Viewed', {
             category: 'cat 1',
             list_id: '1234',
             products: [
-              { product_id: '507f1f77bcf86cd799439011' }
+              { product_id: '507f1f77bcf86cd799439011', productDimension: 'My Product Dimension', productMetric: 'My Product Metric' }
             ],
             testDimension: true,
             testMetric: true
@@ -1105,7 +1105,9 @@ describe('Google Analytics', function() {
             id: '507f1f77bcf86cd799439011',
             category: 'cat 1',
             list: '1234',
-            position: 1
+            position: 1,
+            dimension2: 'My Product Dimension',
+            metric2: 'My Product Metric'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Viewed', {
             dimension1: 'true',
@@ -1117,8 +1119,8 @@ describe('Google Analytics', function() {
         it('should send product impression data via product list filtered', function() {
           // If using addImpression ever becomes optional, will need to add a setting modification here.
           ga.options.setAllMappedProps = false;
-          ga.options.dimensions = { testDimension: 'dimension1' };
-          ga.options.metrics = { testMetric: 'metric1' };
+          ga.options.dimensions = { testDimension: 'dimension1', productDimension: 'dimension2' };
+          ga.options.metrics = { testMetric: 'metric1', productMetric: 'metric2' };
 
           analytics.track('Product List Filtered', {
             category: 'cat 1',
@@ -1136,7 +1138,7 @@ describe('Google Analytics', function() {
               value: 'desc'
             }],
             products: [
-              { product_id: '507f1f77bcf86cd799439011' }
+              { product_id: '507f1f77bcf86cd799439011', productDimension: 'My Product Dimension', productMetric: 'My Product Metric' }
             ],
             testDimension: true,
             testMetric: true
@@ -1148,7 +1150,9 @@ describe('Google Analytics', function() {
             category: 'cat 1',
             list: '1234',
             position: 1,
-            variant: 'department:beauty,price:under::price:desc'
+            variant: 'department:beauty,price:under::price:desc',
+            dimension2: 'My Product Dimension',
+            metric2: 'My Product Metric'
           }]);
           analytics.deepEqual(toArray(window.ga.args[3]), ['send', 'event', 'cat 1', 'Product List Filtered', {
             dimension1: 'true',


### PR DESCRIPTION
Updates the `productListViewedEnhanced` and `productListFilteredEnhanced` functions to map custom dimensions and metrics for products in the `products` array to the `add:Impression` payload.

CC ticket here: https://segment.atlassian.net/browse/CC-3783